### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Creates new project with cropped objects",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
@@ -17,7 +17,9 @@
   "icon": "https://img.icons8.com/color/100/000000/crop--v1.png",
   "icon_background": "#FFFFFF",
   "context_menu": {
-    "target": ["images_project"],
+    "target": [
+      "images_project"
+    ],
     "context_category": "Transform"
   },
   "poster": "https://user-images.githubusercontent.com/48245050/182571801-4c863696-e76f-4e2e-81ec-de6794c257a3.png"

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Creates new project with cropped objects",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "data operations"
   ],
   "description": "Creates new project with cropped objects",
-  "docker_image": "supervisely/data-operations:6.72.201",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.9.11",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   ],
   "description": "Creates new project with cropped objects",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.9.11",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.55
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
